### PR TITLE
Adding a parser for Orca CASSCF

### DIFF
--- a/doc/source/program_specific_information.rst
+++ b/doc/source/program_specific_information.rst
@@ -327,6 +327,35 @@ It is recommended also in this case to read the CI-vectors from the binary file 
 
 In the case of TDA both options work, for RPA ``read_binary=True`` has to be used.
 
+ORCA - CAS
+__________
+TheoDORE is now also able to parse the Tdens-CAS density matrixes from the combination of the ``orca.densities`` and ``orca.densitiesinfo`` files.
+
+1. Run an ORCA job with "!KeepTransDensity" in the simple input line and copy the ``orca.out``, ``orca.gbw``, ``orca.densities`` and ``orca.densitiesinfo`` files. *Note*: the filenames ``orca.densities`` and ``orca.densitiesinfo`` are hardcoded in TheoDORE.
+
+2. Create a molden file using ``orca_2mkl orca -molden``
+
+3. Run Run ``theodore theoinp`` and select ``14`` at
+
+.. code-block:: text
+
+    Type of job (rtype):
+    ...
+      [13]       orca - ORCA TDDFT (using a Molden file and cclib)
+      [14]    orcaCAS - ORCA CAS (using .molden, .densities and .densitiesinfo)
+    ...
+    Choice: 14
+
+This produces the following options in the input file ``dens_ana.in``
+
+.. code-block:: text
+
+  rtype='orcaCAS'
+  rfile='orca.out'
+  read_binary=True
+  mo_file='orca.molden.input'
+
+
 Gaussian - TDDFT
 ~~~~~~~~~~~~~~~~
 Gaussian is parsed with the `cclib library <http://cclib.github.io/>`_. Set the ``pop=full iop(9/40=3)``` option to increase the number of CI vector elements printed.

--- a/theodore/actions/theoinp.py
+++ b/theodore/actions/theoinp.py
@@ -60,6 +60,7 @@ class write_options_theo(input_options.write_options):
             ('terachem', 'Terachem (TDDFT)'),
             ('cclib', 'Use external cclib library: Gaussian, GAMESS, ...'),
             ('orca', 'ORCA TDDFT (using a Molden file and cclib)'),
+            ('orcaCAS', 'ORCA CAS (using .molden, .densities and .densitiesinfo)'),
             ('adf', 'ADF (TDDFT)'),
             ('tddftb', 'DFTB+ - TDDFTB'),
             ('dftmrci', 'DFT/MRCI'),
@@ -129,7 +130,7 @@ class write_options_theo(input_options.write_options):
             self['mo_file'] = 'orbs.mld'
             self['coor_file'] = ''
             self['coor_format'] = ''
-        elif self['rtype'] == 'orca':
+        elif self['rtype'] == 'orca' or self['rtype'] == 'orcaCAS':
             self['rfile'] = 'orca.out'
             self['mo_file'] = 'orca.molden.input'
             self['coor_file'] = ''
@@ -191,6 +192,8 @@ class write_options_theo(input_options.write_options):
                 print("     from the control file before running tm2molden.")
         elif self['rtype'] == 'orca':
             self.read_yn('Read the binary orca.cis file?', 'read_binary', True)
+        elif self['rtype'] == 'orcaCAS':
+            self.read_yn('Read the binary orca.densities and orca.densitiesinfo files?', 'read_binary', True)
 
         # switch for DFTMRCI singlet-singlet / singlet-triplet densities
         if self['rtype'] == 'dftmrci':

--- a/theodore/dens_ana_base.py
+++ b/theodore/dens_ana_base.py
@@ -90,6 +90,8 @@ class dens_ana_base:
             self.state_list = file_parser.file_parser_nos(self.ioptions).read(self.mos)
         elif rtype == 'orca':
             self.state_list = file_parser.file_parser_orca(self.ioptions).read(self.mos)
+        elif rtype == 'orcacas':
+            self.state_list = file_parser.file_parser_orca_CAS(self.ioptions).read(self.mos)
         elif rtype in ['cclib', 'gamess']:
             # these are parsed with the external cclib library
             ccli = cclib_interface.file_parser_cclib(self.ioptions)

--- a/theodore/file_parser.py
+++ b/theodore/file_parser.py
@@ -2141,3 +2141,115 @@ class file_parser_orca(file_parser_base):
                 state['tden'][nfrzc:nocc, nocc:nmo] *= .5
 
         return state_list
+
+class file_parser_orca_CAS(file_parser_base):
+
+    def read(self, mos):
+        return self.tden_orca(mos, False)
+
+    def tden_orca(self, mos, rect_dens, filen1='orca.densities', filen2='orca.densitiesinfo'):
+        '''
+        as far as i found out by looking into multiple files produced by orca6.1 each section has length of 661 bytes starting
+        with a nul terminated string representing that densities name. The header seed to variied in length. It might be also due 
+        the presents of a nul terminated string starting at byte 4 in the data.
+        The first 4 bytes seem to be a uint32/int32 stating the number of available densities.
+
+        '''
+        state_list = []
+
+        outFile = open(self.ioptions['rfile'], 'r')
+        startRead = False
+        for l in outFile:
+            if startRead:
+                if l =="\n":
+                    startRead = False
+                    continue
+
+                words = l.split()
+                state = {'mult': int(words[2][0]), 'irrep': words[2][1:], 'state_ind': len(state_list), 'exc_en': float(words[3])}
+                state['name'] = '%i(%i)%s'%(state['state_ind'], state['mult'] ,state['irrep'])
+                state_list.append(state)
+                
+            elif "                     ABSORPTION SPECTRUM VIA TRANSITION ELECTRIC DIPOLE MOMENTS    \n" == l:
+                [next(outFile) for i in range(4)]
+                state_list = []
+                startRead=True
+            
+
+        dens_info = open(filen2, 'rb')
+        data = dens_info.read()
+        dens_info.close()
+        file_size = len(data)
+        n_sections = struct.unpack('<i', data[:4])[0]
+        header_len = file_size - 661 * n_sections
+        header = data[:header_len]
+
+        parse_instructions = []
+        for i, d in enumerate([data[i : i + 661] for i in range(header_len, len(data), 661)]):
+            name_end = d.find(b'\x00')
+            
+            if name_end != -1:
+                section_name = d[0:name_end].decode('utf-8', errors='ignore')
+            else:
+                section_name = "UNKNOWN_SECTION"
+
+            descript_pos = d.find(b'\xff\xff\xff\xff\xff\xff\xff\xff') + 8
+
+            ambiguous_bytes = d[descript_pos + 8 : descript_pos + 13]     
+            if ambiguous_bytes != b'\x08\x00\x00\x00\x00':
+                print(f'Notice: Ambiguous bytes changed at section {i}: {ambiguous_bytes.hex()}')
+            
+            # in all files i looked the 661 byte long regions starts a 8 byte long FF terminater starting at byte 520, than based on the nuls in the hex
+            # there seed to be multiple int32s and int64s in that region afterwords. The only important here are the first two int32 after the terminator
+            # as these provide the size of the corresponding matrix in .densities. i am not sure which is row and which is call as in all my files they
+            # where square matrixes, i still parse out all the numbers i think i found but i will only use the two mentioned
+            int32_block = d[descript_pos : descript_pos + 8] + d[descript_pos + 13 : descript_pos + 37]
+            int64_block = d[descript_pos + 37:]
+            assert len(int32_block) == 32, len(int32_block)
+            assert len(int64_block) == 96, len(int64_block)
+            
+            unpacked_uint32s = struct.unpack('<IIIIIIII', int32_block)
+            unpacked_uint64s = struct.unpack('<QQQQQQQQQQQQ', int64_block)
+            
+            # selecting only the transition densities starting from the ground root 
+            if ("Tdens-CAS-" in section_name) and (section_name.split('-')[4]=="0") and (section_name.split('-')[5]!="0"):
+                parse_instructions.append((unpacked_uint32s[0], unpacked_uint32s[1]))
+                print(section_name)
+            else:
+                parse_instructions.append(unpacked_uint32s[0] * unpacked_uint32s[1])
+
+
+        # starting here i will actually parse the .densities file. When using a double for each value expected by the matrix sizes gained from the the
+        # densitiesinfo, the length of the densities file fits exactly.
+        bytes_per_value = 8
+        densfile = open(filen1, 'rb')
+
+        print(len(state_list))
+        i = 0
+        for item in parse_instructions:
+            if isinstance(item, int):
+                densfile.seek(bytes_per_value * item, 1)
+            elif isinstance(item, tuple):
+                rows, cols = item # might be flipped. In my data only square matrixes where present."
+                bytes_to_read = bytes_per_value * rows * cols 
+                raw = densfile.read(bytes_to_read)
+
+                if len(raw) != bytes_to_read:
+                    raise EOFError(f"Unexpected end of file while reading matrix of size {rows}x{cols}. Expected {bytes_to_read} bytes, but got {len(raw)} bytes.")
+
+                array = numpy.frombuffer(raw, dtype=numpy.float64).reshape((rows,cols))
+                print(i)
+                state_list[i]['tden'] = array
+                i += 1
+
+        # just doing some sanity check that everything was as expected and we now reached the end of the densities file.
+        extra_byte = densfile.read(1)
+        if extra_byte != b'':
+            current_pos = densfile.tell() - 1  
+            densfile.seek(0, 2)               
+            total_size = densfile.tell()
+            remaining_bytes = total_size - current_pos
+            
+            raise ValueError(f"Layout fully processed, but the end of the file was not reached! There are still {remaining_bytes} unparsed bytes left in '{filen1}'.")
+            
+        return state_list

--- a/theodore/file_parser.py
+++ b/theodore/file_parser.py
@@ -2166,7 +2166,7 @@ class file_parser_orca_CAS(file_parser_base):
                     continue
 
                 words = l.split()
-                state = {'mult': int(words[2][0]), 'irrep': words[2][1:], 'state_ind': len(state_list), 'exc_en': float(words[3])}
+                state = {'mult': int(words[2].split("-")[1][0]), 'irrep': words[2].split("-")[1][1:], 'state_ind': int(words[2].split("-")[0]), 'exc_en': float(words[3])}
                 state['name'] = '%i(%i)%s'%(state['state_ind'], state['mult'] ,state['irrep'])
                 state_list.append(state)
                 
@@ -2224,7 +2224,7 @@ class file_parser_orca_CAS(file_parser_base):
         bytes_per_value = 8
         densfile = open(filen1, 'rb')
 
-        print(len(state_list))
+        print(f"found {len(state_list)} states")
         i = 0
         for item in parse_instructions:
             if isinstance(item, int):
@@ -2237,9 +2237,10 @@ class file_parser_orca_CAS(file_parser_base):
                 if len(raw) != bytes_to_read:
                     raise EOFError(f"Unexpected end of file while reading matrix of size {rows}x{cols}. Expected {bytes_to_read} bytes, but got {len(raw)} bytes.")
 
-                array = numpy.frombuffer(raw, dtype=numpy.float64).reshape((rows,cols))
-                print(i)
-                state_list[i]['tden'] = array
+                D_AO = numpy.frombuffer(raw, dtype=numpy.float64).reshape((rows,cols))
+                temp   = mos.CdotD(D_AO.T, trnsp=False, inv=True)   # C⁻¹ @ D_AOᵀ      → (nmo × nbas)
+                D_MO   = mos.MdotC(temp, trnsp=True, inv=True)      # C⁻¹ @ D_AOᵀ @ C⁻ᵀ  → (nmo × nmo)
+                state_list[i]['tden'] = D_MO
                 i += 1
 
         # just doing some sanity check that everything was as expected and we now reached the end of the densities file.


### PR DESCRIPTION
When using CASSCF calculations in ORCA no orca.cis is created. The best option to still run transition density and CT number analysis i found was to read the .densities and .densitiesinfo binary files (they include Tdens-CAS and Tdens-CASMO matrixes when using !KeepTransDensity in the simple input line). I have added a parser for those files and this should theoretically now work with all calcualtions that internally calculate some kind of transition density. In addtion, the transition details are parsed from the orca.out file and a molden file is used for the LCAO coefficients and basis set infos. The parser reads the Tdens-CAS matrixes (in AO Basis) and uses the coefficient matrix to transform them to the one in MO basis stored in state['tden'].

I have emulated the behavior of the other parsers to the best of my knowledge but were only able to test it for my usecase on a CASSCF calculation on a metal complex. Using the Omega descriptors for transition metal complex, the reported characters match up well with visual examination of the changes in the predominant configurations reported in the orca.out.

i hope it is ok to just contribute this additional parser to the program as the inclusion should not result in any problem. The only problem i could imagine would be that the order of the other parsers in the first input in theoinp changed because i put this parser below the normal orca TDDFT parser but that can be easily switched.